### PR TITLE
\faIconBox{} removed

### DIFF
--- a/yaac-another-awesome-cv.cls
+++ b/yaac-another-awesome-cv.cls
@@ -1,6 +1,6 @@
 %% Copyright 2016 Christophe Roger
 %
-% Author: 
+% Author:
 % Christophe Roger (Darwiin)
 %
 % This work may be distributed and/or modified under the
@@ -12,10 +12,10 @@
 % version 2005/12/01 or later.
 %
 % This work has the LPPL maintenance status `maintained'.
-% 
+%
 % The Current Maintainer of this work is M. C. Roger.
 %
-% This work consists of the files awesome-source-cv.cls 
+% This work consists of the files awesome-source-cv.cls
 
 \ProvidesClass{yaac-another-awesome-cv}[2018/10/17  v1.10.2 'YAAC: Another Awesome CV' Class]
 
@@ -63,12 +63,12 @@
 \RequirePackage[usenames,dvipsnames]{xcolor}
 \RequirePackage{fullpage}
 \RequirePackage[margin=1.5cm]{geometry}
-\RequirePackage{fontawesome5}
+\RequirePackage[fixed]{fontawesome5}
 \RequirePackage{hyperref}
 \RequirePackage{titlesec}
 \RequirePackage{array}
 \RequirePackage{enumitem}
-\RequirePackage{longtable} 	
+\RequirePackage{longtable}
 \RequirePackage{etoolbox}
 \RequirePackage{tikz}
 \RequirePackage[skins]{tcolorbox}
@@ -130,8 +130,8 @@
 \titlespacing{\section}{0pt}{2pt}{2pt}
 
 % Configure list
-\setlist[itemize,1]{label=\faAngleRight, nosep, leftmargin=2em} 
-\setlist[itemize,2]{label=\faAngleRight, nosep, leftmargin=1.5em} 
+\setlist[itemize,1]{label=\faAngleRight, nosep, leftmargin=2em}
+\setlist[itemize,2]{label=\faAngleRight, nosep, leftmargin=1.5em}
 
 % Setup Array : new column type
 \newcolumntype{R}[1]{>{\hfill}m{#1}}
@@ -148,13 +148,13 @@
 {
   %\setmainfont[BoldFont = Helvetica Neue, ItalicFont=Helvetica Neue Thin Italic ,SmallCapsFont = Helvetica Neue Light]{Helvetica Neue Thin}
   \setmainfont{Source Sans Pro Light}[
-    BoldFont = SourceSansPro-Regular, 
+    BoldFont = SourceSansPro-Regular,
     ItalicFont= Source Sans Pro Light Italic]
 }
 {
   \setmainfont{SourceSansPro-Light}[
-    Path = fonts/, 
-    BoldFont = SourceSansPro-Regular, 
+    Path = fonts/,
+    BoldFont = SourceSansPro-Regular,
     ItalicFont = SourceSansPro-LightIt]
 }
 
@@ -165,22 +165,17 @@
 \newlength{\leftcolumn}
 \setlength{\leftcolumn}{2.5cm}
 
-% Font Awesome icons box
-\NewDocumentCommand\faIconBox{m s O{solid}}{
-  \makebox[1.2em][c]{\IfBooleanTF{#2}{\csname fa#1\endcsname*}{\csname fa#1\endcsname}[#3]}
-}
-
 % Font Awesome icons aliases
-\newcommand{\mailSymbol}{\faIconBox{At}}
-\newcommand{\locationSymbol}{\faIconBox{MapMarker}*}
-\newcommand{\infoSymbol}{\faIconBox{Info}}
-\newcommand{\linkedinSymbol}{\faIconBox{LinkedinIn}}
-\newcommand{\viadeoSymbol}{\faIconBox{Viadeo}}
-\newcommand{\mobileSymbol}{\faIconBox{Mobile}*}
-\newcommand{\githubSymbol}{\faIconBox{Github}}
-\newcommand{\mediumSymbol}{\faIconBox{Medium}}
-\newcommand{\bitbucketSymbol}{\faIconBox{Bitbucket}}
-\newcommand{\websiteSymbol}{\faIconBox{Link}}
+\newcommand{\mailSymbol}{\faAt}
+\newcommand{\locationSymbol}{\faMapMarker*}
+\newcommand{\infoSymbol}{\faInfo}
+\newcommand{\linkedinSymbol}{\faLinkedinIn}
+\newcommand{\viadeoSymbol}{\faViadeo}
+\newcommand{\mobileSymbol}{\faMobile*}
+\newcommand{\githubSymbol}{\faGithub}
+\newcommand{\mediumSymbol}{\faMedium}
+\newcommand{\bitbucketSymbol}{\faBitbucket}
+\newcommand{\websiteSymbol}{\faLink}
 
 
 \newcommand\link[2]{\color{linkcolor}\href{#1}{#2}\color{Black} }
@@ -237,7 +232,7 @@
 
 % Render author's viadeo(optional)
 % Usage: \viadeo{<viadeo-nick>}
-\newcommand*{\viadeo}[1]{\sociallink{\viadeoSymbol}{http://www.viadeo.com/fr/profile/#1}{viadeo.com/fr/profile/#1}} 
+\newcommand*{\viadeo}[1]{\sociallink{\viadeoSymbol}{http://www.viadeo.com/fr/profile/#1}{viadeo.com/fr/profile/#1}}
 
 % Render author's github (optional)
 % Usage: \github{<github-nick>}
@@ -245,7 +240,7 @@
 
 % Render author's medium (optional)
 % Usage: \medium{<medium-nick>}
-\newcommand*{\medium}[1]{\sociallink{\mediumSymbol}{https://www.medium.com/@#1}{medium.com/#1}} 
+\newcommand*{\medium}[1]{\sociallink{\mediumSymbol}{https://www.medium.com/@#1}{medium.com/#1}}
 
 % Render author's bitbucket (optional)
 % Usage: \bitbucket{<bitbucket-account-name>}
@@ -261,7 +256,7 @@
 
 % Render author's mobile phone (optional)
 % Usage: \smartphone{<mobile phone number>}
-\newcommand*\smartphone[1]{\socialtext{\mobileSymbol}{#1}}    
+\newcommand*\smartphone[1]{\socialtext{\mobileSymbol}{#1}}
 
 % Render author's tagline
 \newcommand\resumetitle[1]{
@@ -336,7 +331,7 @@
 \newenvironment{keywords}{%
   \renewcommand{\arraystretch}{1.1}
 
-  \begin{tabular}{>{}r>{}p{13cm}} 
+  \begin{tabular}{>{}r>{}p{13cm}}
 }{%
   \end{tabular}
 }
@@ -344,7 +339,7 @@
 % Render a scholarshipentry in the scolarship environment
 % Usage: \scholarshipentry{<date>}{<description>}
 \newcommand\keywordsentry[2]{
-  \textbf{#1} &   #2\\ 
+  \textbf{#1} &   #2\\
 }
 
 % Define a new column type for the scholarship environment
@@ -386,7 +381,7 @@
 }
 
 % Render an experience in the experiences environment
-% Usage: 
+% Usage:
 % \experience
 %  {<End date>}      {<Title>}{<Enterprise>}{<Country>}
 %  {<Start date}     {
@@ -402,7 +397,7 @@
   }
 
 % Render a consultant experience in the experiences environment
-% Usage: 
+% Usage:
 % \consultantexperience
 %  {<End date>}      {<Consultant title>}{<Consulting Enterprise>}{<Country>}
 %  {<Start date}     {<Client title>}{<Client business unit>}
@@ -469,7 +464,7 @@
     \begin{tabular}{>{}l >{}l}
       \multicolumn{2}{l}{\textbf{#1}}\\
       \multicolumn{2}{l}{\emph{#2}, \textsc{#3}}\\
-      \quad \mailSymbol & \href{mailto:#4}{#4} \\  
+      \quad \mailSymbol & \href{mailto:#4}{#4} \\
       \quad \faPhone & #5 \\
     \end{tabular}
   \end{minipage}%
@@ -481,7 +476,7 @@
     \begin{tabular}{>{}l >{}l}
       \multicolumn{2}{l}{\textbf{#1}}\\
       \multicolumn{2}{l}{\emph{#2}, \textsc{#3}}\\
-      \quad \mailSymbol & \href{mailto:#4}{#4} \\  
+      \quad \mailSymbol & \href{mailto:#4}{#4} \\
     \end{tabular}
   \end{minipage}%
 }


### PR DESCRIPTION
It isn't needed anymore \faIconBox{} trick, fontawesome5 has added [fixed] that does exactly the same but natively. I made all the necessary changes. 

Dependencies: fontawesome5 version 5.4.1 dated 2018/10/13

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [?] I have checked that the original example is succesfully built on circleci
circleci uses an outdated texlive-fonts-extra where fontawesome5 version 5.4.1 is not included, so PDF built is unsuccessful