### PR TITLE
README.md: Fix minor typo and link path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-YAAC: Another Awesome CV [![CircleCI](https://circleci.com/gh/darwiin/yaac-another-awesome-cv.svg?style=svg)](https://circleci.com/gh/darwiin/yaac-another-awesome-cv) [![Example](https://img.shields.io/badge/Exemple-pdf-blue.svg)](https://github.com/darwiin/yaac-another-awesome-cv/releases/download/v1.8.0/cv.pdf)
+YAAC: Another Awesome CV [![CircleCI](https://circleci.com/gh/darwiin/yaac-another-awesome-cv.svg?style=svg)](https://circleci.com/gh/darwiin/yaac-another-awesome-cv) [![Example](https://img.shields.io/badge/Example-pdf-blue.svg)](https://github.com/darwiin/yaac-another-awesome-cv/releases/download/v1.7.0/cv.pdf)
 =================
 
 ## Quick start


### PR DESCRIPTION
# Description

Fixed something in `README.md`, including:
* Minor typo of badge
* Link to example CV. It seems that v1.8.0 is not tagged, so I changed it to the latest release v1.7.0.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist
*No code change so it might be unneeded.*

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have checked that the original example is succesfully built on circleci
