### PR TITLE
Added StackOverflow and StackExchange to list of social info accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ Outside of the `\socialinfo` wrapper you have to define the mandatory parameters
 \name{Christophe}{ROGER}
 
 % Define author's photo (optional)
-% Usage \photo{<diameter>}{<photo>}
+% Usage: \photo[<shape: circular, square>]{<diameter>}{<photo>}
+% The shape of the author's photo is circular by default.
 \photo{2.5cm}{darwiin}
 
 % Define author's tagline

--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ Most social network have their command to render a clickable link or a simple te
 % Usage: \github{<github-nick>}
 \github{darwiin}
 
+% Render author's stackoverflow profile (optional)
+% Usage: \stackoverflow{<stackoverflow-user-id>}
+\stackoverflow{759643}
+
+% Render author's stackexchange profile (optional)
+% Usage: \stackexchange{<stackexchange-user-id>}
+\stackexchange{396216}
+
 % Render author's email (optional)
 % Usage: \email{<email adress>}
 \email{christophe.roger@mail.com}

--- a/yaac-another-awesome-cv.cls
+++ b/yaac-another-awesome-cv.cls
@@ -173,6 +173,8 @@
 \newcommand{\viadeoSymbol}{\faViadeo}
 \newcommand{\mobileSymbol}{\faMobile*}
 \newcommand{\githubSymbol}{\faGithub}
+\newcommand{\stackoverflowSymbol}{\faStackOverflow}
+\newcommand{\stackexchangeSymbol}{\faStackExchange}
 \newcommand{\mediumSymbol}{\faMedium}
 \newcommand{\bitbucketSymbol}{\faBitbucket}
 \newcommand{\websiteSymbol}{\faLink}
@@ -237,6 +239,14 @@
 % Render author's github (optional)
 % Usage: \github{<github-nick>}
 \newcommand*{\github}[1]{\sociallink{\githubSymbol}{https://www.github.com/#1}{github.com/#1}}           % Github icon + URL
+
+% Render author's stackoverflow profile (optional)
+% Usage: \stackoverflow{<stackoverflow-user-id>}
+\newcommand*{\stackoverflow}[1]{\sociallink{\stackoverflowSymbol}{https://www.stackoverflow.com/u/#1}{stackoverflow.com/u/#1}}
+
+% Render author's stackexchange profile (optional)
+% Usage: \stackexchange{<stackexchange-user-id>}
+\newcommand*{\stackexchange}[1]{\sociallink{\stackexchangeSymbol}{https://stackexchange.com/users/#1}{stackexchange.com/users/#1}}
 
 % Render author's medium (optional)
 % Usage: \medium{<medium-nick>}

--- a/yaac-another-awesome-cv.cls
+++ b/yaac-another-awesome-cv.cls
@@ -73,6 +73,7 @@
 \RequirePackage{tikz}
 \RequirePackage[skins]{tcolorbox}
 \RequirePackage{fancyhdr}
+\RequirePackage{ifthen}
 
 
 \DeclareUnicodeCharacter{00E9}{\'{e}}
@@ -217,8 +218,9 @@
 \newcommand*{\tagline}[1]{\def\@tagline{#1}}
 
 % Define author's photo
-% Usage \photo{<diameter>}{<photo>}
-\newcommand{\photo}[2]{\def\@photo{#2}\def\@photodiameter{#1}}
+% Usage: \photo[<shape: circular, square>]{<diameter>}{<photo>}
+% The shape of the author's photo is circular by default.
+\newcommand{\photo}[3][circular]{\def\@photo{#3}\def\@photodiameter{#2}\def\@photoshape{#1}}
 
 % Render author's address
 % Usage: \address{<address>}
@@ -281,7 +283,13 @@
 }
 
 \newcommand\idphoto{
-  \tikz\path[fill overzoom image={\@photo}]circle[radius=0.5\linewidth];
+	\ifthenelse{\equal{\@photoshape}{square}}{
+		% Draw square photo
+		\tikz\path[fill overzoom image={\@photo}]rectangle(\linewidth,\linewidth);
+	}{
+		% Draw circular photp
+		\tikz\path[fill overzoom image={\@photo}]circle[radius=0.5\linewidth];
+	}
 }
 
 % Define social entries to print in header


### PR DESCRIPTION
# Description

Added StackOverflow and StackExchange to list of social info accounts.
For instance, the command `\stackoverflow{759643}` outputs the link [https://stackoverflow.com/u/759643](https://stackoverflow.com/u/759643) and the command `\stackexchange{396216}` outputs the link [https://stackexchange.com/users/396216](https://stackexchange.com/users/396216) with a corresponding icon in the social info section.


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have checked that the original example is successfully built on CircleCI
