### PR TITLE
Remove luainputenc to fix build error with xelatex

### DIFF
--- a/yaac-another-awesome-cv.cls
+++ b/yaac-another-awesome-cv.cls
@@ -67,7 +67,6 @@
 % Dependences
 %A Few Useful Packages
 \RequirePackage[english,french]{babel}
-\RequirePackage[utf8]{luainputenc}
 \RequirePackage{fontspec} 					                 % for loading fonts
 \RequirePackage{url,parskip} 	    % other packages for formatting
 \RequirePackage[usenames,dvipsnames]{xcolor}
@@ -86,7 +85,6 @@
 \RequirePackage{ifthen}
 
 
-\DeclareUnicodeCharacter{00E9}{\'{e}}
 % Define default accent colors
 \definecolor{basecolor}{HTML}{000066}       %BLUE
 


### PR DESCRIPTION
Right now the project fails to build. `luatex` returns an error I don't manage to fix (#51) and `xelatex` complains about `luainputenc`.

From what I read,  `luainputenc` is only made for compatibility with old documents. Removing it allowed me to successfully build `cv.tex`.

NB: `\DeclareUnicodeCharacter` is no longer needed with `xelatex`.